### PR TITLE
[REFACTOR] isMyTurn 관련 스케줄러 로직 처리

### DIFF
--- a/src/main/java/ssu/today/domain/diary/entity/DiaryBundle.java
+++ b/src/main/java/ssu/today/domain/diary/entity/DiaryBundle.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssu.today.domain.shareGroup.entity.ShareGroup;
+import ssu.today.global.entity.BaseTimeEntity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,7 +27,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class DiaryBundle {
+public class DiaryBundle extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diary_bundle_id")

--- a/src/main/java/ssu/today/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/ssu/today/domain/diary/repository/DiaryRepository.java
@@ -3,11 +3,18 @@ package ssu.today.domain.diary.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ssu.today.domain.diary.entity.Diary;
+import ssu.today.domain.diary.entity.DiaryBundle;
+import ssu.today.domain.shareGroup.entity.Profile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     // 특정 번들에 속한 다이어리들을 최신순으로 조회
     List<Diary> findAllByDiaryBundle_IdAndDiaryBundle_ShareGroup_IdOrderByCreatedAtDesc(Long diaryBundleId, Long shareGroupId);
+    // 오늘 이미 다이어리를 업로드했는지 확인
+    boolean existsByProfileAndCreatedAt(Profile profile, LocalDateTime createdAt);
+    // 특정 DiaryBundle 내에서 해당 프로필로 작성된 다이어리의 수를 확인
+    int countByDiaryBundleAndProfile(DiaryBundle diaryBundle, Profile profile);
 }

--- a/src/main/java/ssu/today/domain/diary/scheduler/DiaryBundleScheduler.java
+++ b/src/main/java/ssu/today/domain/diary/scheduler/DiaryBundleScheduler.java
@@ -6,30 +6,37 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import ssu.today.domain.diary.entity.DiaryBundle;
 import ssu.today.domain.diary.repository.DiaryBundleRepository;
+import ssu.today.domain.shareGroup.entity.Profile;
 import ssu.today.domain.shareGroup.entity.ShareGroup;
-import ssu.today.domain.shareGroup.repository.ShareGroupRepository;
+import ssu.today.domain.shareGroup.repository.ProfileRepository;
+import ssu.today.domain.shareGroup.service.ShareGroupService;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class DiaryBundleScheduler {
 
-    private final ShareGroupRepository shareGroupRepository;
     private final DiaryBundleRepository diaryBundleRepository;
+    private final ShareGroupService shareGroupService;
+    private final ProfileRepository profileRepository;
 
     // 모든 공유 그룹에 대해 번들을 생성하거나 업데이트하는 함수
     // 자정 5분 후 매일 실행
     @Scheduled(cron = "0 5 0 * * *")
     @Transactional
     public void createBundlesForAllShareGroups() {
-        // 모든 공유 그룹을 가져옴
-        List<ShareGroup> allShareGroups = shareGroupRepository.findAll();
+        // active 상태인 모든 공유 그룹을 가져옴
+        List<ShareGroup> activeShareGroups = shareGroupService.getActiveShareGroups();
 
         // 각 공유 그룹에 대해 번들 생성 작업 수행
-        for (ShareGroup shareGroup : allShareGroups) {
+        for (ShareGroup shareGroup : activeShareGroups) {
             createOrUpdateBundleForShareGroup(shareGroup);
+            updateIsMyTurnForShareGroup(shareGroup);  // isMyTurn 필드 업데이트
         }
     }
 
@@ -38,18 +45,14 @@ public class DiaryBundleScheduler {
 
         LocalDateTime now = LocalDateTime.now();
 
-        // 1. 공유 그룹의 openAt이 현재보다 이전이면 번들을 생성할 시점인지 확인
-        if (now.isAfter(shareGroup.getOpenAt())) {
+        // 1. 제일 최신 번들 가져오기
+        DiaryBundle latestBundle = diaryBundleRepository.findFirstByShareGroupOrderByStartedAtDesc(shareGroup)
+                .orElse(null);
 
-            // 2. 제일 최신 번들 가져오기
-            DiaryBundle latestBundle = diaryBundleRepository.findFirstByShareGroupOrderByStartedAtDesc(shareGroup)
-                    .orElse(null);
-
-            // 3. 번들을 새로 생성해야 하는지 확인
-            if (latestBundle == null || shouldCreateNewBundle(latestBundle, shareGroup)) {
-                // 새로운 번들 생성
-                createNewBundle(shareGroup);
-            }
+        // 2. 번들을 새로 생성해야 하는지 확인
+        if (latestBundle == null || shouldCreateNewBundle(latestBundle, shareGroup)) {
+            // 새로운 번들 생성
+            createNewBundle(shareGroup);
         }
     }
 
@@ -83,5 +86,35 @@ public class DiaryBundleScheduler {
         LocalDateTime now = LocalDateTime.now();
         return now.isAfter(latestBundle.getEndedAt());
     }
+
+    // 공유 그룹 멤버들의 isMyTurn 필드를 업데이트하는 함수
+    private void updateIsMyTurnForShareGroup(ShareGroup shareGroup) {
+        // 공유 그룹의 모든 멤버 가져오기 (profileId 기준으로 정렬해서 순서 보장 문제 해결)
+        List<Profile> profileList = shareGroupService.findProfileListByShareGroupId(shareGroup.getId())
+                .stream() //리스트는 sorted연산 사용 불가, stream 사용
+                .sorted(Comparator.comparing(Profile::getId))  // profileId 순으로 정렬
+                .toList();
+
+        // 공유 그룹의 시작일을 기준으로 몇 번째 날인지 계산 (년도가 아니라 오픈일 기준이라, 년도변경시 초기화되는 문제 해결)
+        LocalDate startDate = shareGroup.getOpenAt().toLocalDate();
+        int daysSinceStart = (int) ChronoUnit.DAYS.between(startDate, LocalDate.now());
+        int dayOfBundle = daysSinceStart % shareGroup.getMemberCount();  // 나머지 연산으로 몇 번째 날인지 계산
+
+        // 각 멤버의 차례를 설정 (하루에 한 명씩 돌아가면서 isMyTurn 설정)
+        for (int i = 0; i < profileList.size(); i++) {
+            Profile profile = profileList.get(i);
+
+            // 자신의 차례이면 isMyTurn을 true로 설정, 아니면 false로 설정
+            if (i == dayOfBundle) {
+                profile.setIsMyTurn(true);
+            } else {
+                profile.setIsMyTurn(false);
+            }
+
+            profileRepository.save(profile);  // 변경사항 저장
+        }
+    }
+
+
 }
 

--- a/src/main/java/ssu/today/domain/diary/scheduler/DiaryBundleScheduler.java
+++ b/src/main/java/ssu/today/domain/diary/scheduler/DiaryBundleScheduler.java
@@ -117,4 +117,3 @@ public class DiaryBundleScheduler {
 
 
 }
-

--- a/src/main/java/ssu/today/domain/shareGroup/Scheduler/ShareGroupScheduler.java
+++ b/src/main/java/ssu/today/domain/shareGroup/Scheduler/ShareGroupScheduler.java
@@ -1,0 +1,48 @@
+package ssu.today.domain.shareGroup.Scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import ssu.today.domain.shareGroup.entity.ShareGroup;
+import ssu.today.domain.shareGroup.repository.ShareGroupRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static ssu.today.domain.shareGroup.entity.Status.ACTIVE;
+import static ssu.today.domain.shareGroup.entity.Status.PENDING;
+
+@Component
+@RequiredArgsConstructor
+public class ShareGroupScheduler {
+
+    private final ShareGroupRepository shareGroupRepository;
+
+    /**
+     * 매시간 실행되는 스케줄링 작업: 24시간이 지난 PENDING 상태의 그룹을 ACTIVE로 변경하고 초대 코드를 무효화
+     * */
+    @Scheduled(cron = "30 0 0 * * *") // 매일 자정(00시) 0분 30초마다 스케줄러 실행
+    @Transactional
+    public void updatePendingGroups() {
+
+        // 현재 시간 계산
+        LocalDateTime now = LocalDateTime.now();
+
+        // 현재 시간보다 openAt이 지난 PENDING 상태의 그룹들만 조회
+        List<ShareGroup> pendingGroups = shareGroupRepository.findAllByStatusAndOpenAtBefore(PENDING, now);
+
+        // 조회된 각 그룹에 대해 상태를 ACTIVE로 변경하고 초대 코드를 무효화시킴
+        for (ShareGroup shareGroup : pendingGroups) {
+            updateGroupStatus(shareGroup);
+        }
+    }
+
+    @Transactional
+    public void updateGroupStatus(ShareGroup shareGroup) {
+        shareGroup.setStatus(ACTIVE);  // 상태를 ACTIVE로 변경
+        shareGroup.setInviteCode("NULL");       // 초대 코드를 무효화
+        shareGroupRepository.save(shareGroup); // 변경된 정보를 데이터베이스에 저장
+        shareGroupRepository.flush(); // 강제로 변경사항 커밋 ..
+    }
+}

--- a/src/main/java/ssu/today/domain/shareGroup/entity/Profile.java
+++ b/src/main/java/ssu/today/domain/shareGroup/entity/Profile.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.SQLRestriction;
 import ssu.today.domain.member.entity.Member;
 
@@ -25,6 +26,7 @@ import java.time.LocalDateTime;
 @Table(name = "profiles")
 @SQLRestriction("deleted_at is NULL")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/ssu/today/domain/shareGroup/repository/ShareGroupRepository.java
+++ b/src/main/java/ssu/today/domain/shareGroup/repository/ShareGroupRepository.java
@@ -19,4 +19,6 @@ public interface ShareGroupRepository extends JpaRepository<ShareGroup, Long> {
     //페이징 처리해서 shareGroup 가져오기
     Page<ShareGroup> findByIdIn(List<Long> shareGroupIds, Pageable pageable);
     Page<ShareGroup> findByIdInAndStatus(List<Long> ids, Status status, Pageable pageable);
+    // 상태가 ACTIVE인 모든 공유 그룹 조회
+    List<ShareGroup> findByStatus(Status status);
 }

--- a/src/main/java/ssu/today/domain/shareGroup/service/ShareGroupService.java
+++ b/src/main/java/ssu/today/domain/shareGroup/service/ShareGroupService.java
@@ -23,4 +23,5 @@ public interface ShareGroupService {
     List<Profile> findProfileListByShareGroupId(Long shareGroupId);
     Profile findProfile(Long profileId);
     boolean doesProfileExist(Long shareGroupId, Long memberId);
+    List<ShareGroup> getActiveShareGroups();
 }

--- a/src/main/java/ssu/today/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/ssu/today/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -131,33 +131,6 @@ public class ShareGroupServiceImpl implements ShareGroupService {
         return profile;  // 새로 생성된 프로필 반환
     }
 
-    /**
-     * 매시간 실행되는 스케줄링 작업: 24시간이 지난 PENDING 상태의 그룹을 ACTIVE로 변경하고 초대 코드를 무효화
-     * */
-    @Scheduled(cron = "30 0 0 * * *") // 매일 자정(00시) 0분 30초마다 스케줄러 실행
-    @Transactional
-    public void updatePendingGroups() {
-
-        // 현재 시간 계산
-        LocalDateTime now = LocalDateTime.now();
-
-        // 현재 시간보다 openAt이 지난 PENDING 상태의 그룹들만 조회
-        List<ShareGroup> pendingGroups = shareGroupRepository.findAllByStatusAndOpenAtBefore(PENDING, now);
-
-        // 조회된 각 그룹에 대해 상태를 ACTIVE로 변경하고 초대 코드를 무효화시킴
-        for (ShareGroup shareGroup : pendingGroups) {
-            updateGroupStatus(shareGroup);
-        }
-    }
-
-    @Transactional
-    public void updateGroupStatus(ShareGroup shareGroup) {
-        shareGroup.setStatus(ACTIVE);  // 상태를 ACTIVE로 변경
-        shareGroup.setInviteCode("NULL");       // 초대 코드를 무효화
-        shareGroupRepository.save(shareGroup); // 변경된 정보를 데이터베이스에 저장
-        shareGroupRepository.flush(); // 강제로 변경사항 커밋 ..
-    }
-
     // openAt 계산 로직
     private LocalDateTime calculateOpenAt(LocalDateTime createdAt) {
 

--- a/src/main/java/ssu/today/domain/shareGroup/service/ShareGroupServiceImpl.java
+++ b/src/main/java/ssu/today/domain/shareGroup/service/ShareGroupServiceImpl.java
@@ -277,4 +277,10 @@ public class ShareGroupServiceImpl implements ShareGroupService {
     public boolean doesProfileExist(Long shareGroupId, Long memberId) {
         return profileRepository.existsByShareGroupIdAndMemberId(shareGroupId, memberId);
     }
+
+    // ACTIVE 상태의 공유 그룹 리스트 반환
+    @Override
+    public List<ShareGroup> getActiveShareGroups() {
+        return shareGroupRepository.findByStatus(ACTIVE);
+    }
 }

--- a/src/main/java/ssu/today/global/error/code/DiaryErrorCode.java
+++ b/src/main/java/ssu/today/global/error/code/DiaryErrorCode.java
@@ -10,6 +10,8 @@ public enum DiaryErrorCode implements ErrorCode {
     DIARY_BUNDLE_NOT_FOUND(400, "EJ001", "다이어리 bundle을 찾을 수 없습니다."),
     INVALID_TAG_PROFILE(400, "EJ002", "태그한 프로필이 존재하지 않습니다. 다시 입력해 주세요."),
     DIARY_NOT_FOUND(400,"EJ003", "해당 다이어리가 존재하지 않습니다." ),
+    NOT_YOUR_TURN(400, "EJ004", "현재 다이어리를 업로드할 차례가 아닙니다."),
+    ALREADY_EXISTS_DIARY(400, "EJ005", "이미 이 번들 안에서 다이어리를 작성했습니다."),
     ;
 
     private final int status;


### PR DESCRIPTION
1. 본인 차례여야 가능하게 예외처리
2. 본인 차례가 계속 바뀌게 스케줄러 처리

[주안점]
1번 로직 처리.
< 다이어리 작성 로직 리팩토링>
* 다이어리 업로드 시 본인 차례여야 가능하게 수정
* 다이어리를 하루에 한 번만 업로드 가능하게 수정
로직 처리 방식 검증 1. 작성자가 다이어리를 업로드할 차례인지 검증
* 프로필의 isMyTurn 필드가 true여야만 업로드 가능
검증 2. 다이어리 개수 검증
* 가장 최신 DiaryBundle(주기)을 가져옵니다.
* 해당 번들 내에서 해당 프로필로 작성된 다이어리의 개수를 파악합니다.
* 한 주기에 작성한 다이어리 개수가 1개 이상이면 에러 처리 하였습니다.


2번 로직 처리.
< isMyTurn이 매일 바뀌며돌아가도록 스케줄링 추가>

!!1번 시도!!
(active인 그룹에 대해) 자정마다 번들을 생성 작업을 시행할 때, 
isMyTurn 필드를 업데이트하는 함수를 추가하였음.  
- 이때 오늘이 1년의 몇번째 날인지를 가져와서, 멤버 수로 나눈 나머지를 얻음
- 그럼 4인 기준 0~3의 값이 나오는데, 이걸 인덱스 삼아서 
- 공유그룹 멤버를 전부 가져와서 이 인덱스가 본인의 차례(0~3 사이)에 해당하면 ismyTurn을  true로, 아니라면 false로 세팅함.
- 이후 변경사항 저장
List<Profile> members = shareGroupService.findByShareGroup(shareGroup); // 멤버 리스트 가져오기
LocalDateTime now = LocalDateTime.now(); 
int dayOfBundle = now.getDayOfYear() % shareGroup.getMemberCount(); // 몇 번째 날인지 계산


!!2번 시도!!

1번에서 발견한 문제점
1. 년도가 바뀌면 초기화되는거 아니야? 
2.  Profile member = members.get(i); 로 멤버를 순회할 때, 이 순회가 항상 같은 차례로 돌아간다고 보장할 수있어?

년도 변경 문제와 순서 보장 문제 발생.

1. 공유 그룹 시작일 기준으로 차례 계산하도록 개선 // 공유 그룹의 시작일을 기준으로 몇 번째 날인지 계산  LocalDate startDate = shareGroup.getOpenAt().toLocalDate();  int daysSinceStart = (int) ChronoUnit.DAYS.between(startDate, LocalDate.now());  int dayOfBundle = daysSinceStart % shareGroup.getMemberCount(); // 몇 번째 날인지 계산
- ChronoUnit.DAYS.between()을 사용해 공유 그룹의 시작일과 현재 날짜 간의 차이를 계산했음.

2. 공유그룹의 멤버를 가져올 때, profileId를 기준으로 정렬하도록 개선 List<Profile> profileList = shareGroupService.findProfileListByShareGroupId(shareGroup.getId())
.stream()
.sorted(Comparator.comparing(Profile::getId))  // profileId 순으로 정렬
.toList();

서비스단 함수로 프로필 리스트를 가져와서 -> stream 으로 변환(변환하지 않으면 sort함수 사용불가)
-> 이걸 sorted함수로 id순으로 정렬 -> 다시 리스트로 변환
